### PR TITLE
feat: implement Lighthouse score cards integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,12 @@ npm run format             # Format with Prettier
 - `PerformanceTestRunner` orchestrates: setup → warmup (CI default) → test → assertions → cleanup
 - Cross-boundary communication via `page.evaluate(() => window.__REACT_PERFORMANCE__)`
 
+**Lighthouse Layer** (`src/lighthouse/`): Page-level audits
+
+- `createLighthouseTest()` extends Playwright with `test.lighthouse()` method
+- `LighthouseTestRunner` runs Lighthouse audits via CDP and enforces score thresholds
+- Separate from performance tests - use for page-level audits, not React-specific profiling
+
 ### CDP Feature Plugin System
 
 All Chrome DevTools Protocol features (CPU/network throttling, FPS, memory, trace export) use a unified plugin architecture with registry-based lifecycle management:
@@ -62,6 +68,7 @@ await handle?.stop(); // Returns metrics and cleans up CDP session
 - `react-performance-tracking` - Main entry (re-exports both layers)
 - `react-performance-tracking/react` - React provider/hooks only
 - `react-performance-tracking/playwright` - Playwright test utilities only
+- `react-performance-tracking/lighthouse` - Lighthouse audit utilities (requires `lighthouse` peer dep)
 
 **Store Structure:**
 
@@ -141,7 +148,8 @@ site/pages/docs/
 │   ├── thresholds.mdx     # Performance budgets
 │   ├── throttling.mdx     # CPU/network throttling
 │   ├── custom-metrics.mdx # Custom marks/measures
-│   └── config-builder.mdx # Interactive config tool
+│   ├── config-builder.mdx # Interactive config tool
+│   └── lighthouse.mdx     # Lighthouse audits
 ├── api/
 │   ├── react.mdx          # React hooks & provider
 │   ├── playwright.mdx     # Playwright test API

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -53,7 +53,11 @@ export default tseslint.config(
 
   // Allow console in logger implementation and structured logging output
   {
-    files: ['src/utils/logger.ts', 'src/playwright/assertions/logging.ts'],
+    files: [
+      'src/utils/logger.ts',
+      'src/playwright/assertions/logging.ts',
+      'src/lighthouse/lighthouseAssertions.ts',
+    ],
     rules: {
       'no-console': 'off',
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-performance-tracking",
-  "version": "0.1.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-performance-tracking",
-      "version": "0.1.1",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -27,6 +27,7 @@
         "globals": "^16.5.0",
         "husky": "^9.1.7",
         "jsdom": "^27.3.0",
+        "lighthouse": "^13.0.1",
         "lint-staged": "^16.2.7",
         "playwright-core": "1.46.1",
         "prettier": "^3.0.0",
@@ -44,10 +45,14 @@
       },
       "peerDependencies": {
         "@playwright/test": "^1.40.0",
+        "lighthouse": ">=11.0.0",
         "react": "^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@playwright/test": {
+          "optional": true
+        },
+        "lighthouse": {
           "optional": true
         },
         "react": {
@@ -566,7 +571,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1423,6 +1428,62 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@fortawesome/fontawesome-free": {
       "version": "6.7.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
@@ -1666,6 +1727,590 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
+      "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+      "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-amqplib": {
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.46.1.tgz",
+      "integrity": "sha512-AyXVnlCf/xV3K/rNumzKxZqsULyITJH6OVLiW6730JPRqWA7Zc9bvYoVNpN6iOpTU8CasH34SU/ksVJmObFibQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-connect": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.43.1.tgz",
+      "integrity": "sha512-ht7YGWQuV5BopMcw5Q2hXn3I8eG8TH0J/kc/GMcW4CuNTgiP6wCu44BOnucJWL3CmFWaRHI//vWyAhaC8BwePw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/connect": "3.4.38"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-dataloader": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.16.1.tgz",
+      "integrity": "sha512-K/qU4CjnzOpNkkKO4DfCLSQshejRNAJtd4esgigo/50nxCB6XCyi1dhAblUHM9jG5dRm8eu0FB+t87nIo99LYQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-express": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.47.1.tgz",
+      "integrity": "sha512-QNXPTWteDclR2B4pDFpz0TNghgB33UMjUt14B+BZPmtH1MwUFAfLHBaP5If0Z5NZC+jaH8oF2glgYjrmhZWmSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.19.1.tgz",
+      "integrity": "sha512-6g0FhB3B9UobAR60BGTcXg4IHZ6aaYJzp0Ki5FhnxyAPt8Ns+9SSvgcrnsN2eGmk3RWG5vYycUGOEApycQL24A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-generic-pool": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.43.1.tgz",
+      "integrity": "sha512-M6qGYsp1cURtvVLGDrPPZemMFEbuMmCXgQYTReC/IbimV5sGrLBjB+/hANUpRZjX67nGLdKSVLZuQQAiNz+sww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-graphql": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.47.1.tgz",
+      "integrity": "sha512-EGQRWMGqwiuVma8ZLAZnExQ7sBvbOx0N/AE/nlafISPs8S+QtXX+Viy6dcQwVWwYHQPAcuY3bFt3xgoAwb4ZNQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-hapi": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.45.2.tgz",
+      "integrity": "sha512-7Ehow/7Wp3aoyCrZwQpU7a2CnoMq0XhIcioFuKjBb0PLYfBfmTsFTUyatlHu0fRxhwcRsSQRTvEhmZu8CppBpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.57.2.tgz",
+      "integrity": "sha512-1Uz5iJ9ZAlFOiPuwYg29Bf7bJJc/GeoeJIFKJYQf67nTVKFe8RHbEtxgkOmK4UGZNHKXcpW4P8cWBYzBn1USpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/instrumentation": "0.57.2",
+        "@opentelemetry/semantic-conventions": "1.28.0",
+        "forwarded-parse": "2.1.2",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-ioredis": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.47.1.tgz",
+      "integrity": "sha512-OtFGSN+kgk/aoKgdkKQnBsQFDiG8WdCxu+UrHr0bXScdAmtSzLSraLo7wFIb25RVHfRWvzI5kZomqJYEg/l1iA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/redis-common": "^0.36.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-kafkajs": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.7.1.tgz",
+      "integrity": "sha512-OtjaKs8H7oysfErajdYr1yuWSjMAectT7Dwr+axIoZqT9lmEOkD/H/3rgAs8h/NIuEi2imSXD+vL4MZtOuJfqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-knex": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.44.1.tgz",
+      "integrity": "sha512-U4dQxkNhvPexffjEmGwCq68FuftFK15JgUF05y/HlK3M6W/G2iEaACIfXdSnwVNe9Qh0sPfw8LbOPxrWzGWGMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-koa": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.47.1.tgz",
+      "integrity": "sha512-l/c+Z9F86cOiPJUllUCt09v+kICKvT+Vg1vOAJHtHPsJIzurGayucfCMq2acd/A/yxeNWunl9d9eqZ0G+XiI6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.44.1.tgz",
+      "integrity": "sha512-5MPkYCvG2yw7WONEjYj5lr5JFehTobW7wX+ZUFy81oF2lr9IPfZk9qO+FTaM0bGEiymwfLwKe6jE15nHn1nmHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.52.0.tgz",
+      "integrity": "sha512-1xmAqOtRUQGR7QfJFfGV/M2kC7wmI2WgZdpru8hJl3S0r4hW0n3OQpEHlSGXJAaNFyvT+ilnwkT+g5L4ljHR6g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongoose": {
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.46.1.tgz",
+      "integrity": "sha512-3kINtW1LUTPkiXFRSSBmva1SXzS/72we/jL22N+BnF3DFcoewkdkHPYOIdAAk9gSicJ4d5Ojtt1/HeibEc5OQg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.45.1.tgz",
+      "integrity": "sha512-TKp4hQ8iKQsY7vnp/j0yJJ4ZsP109Ht6l4RHTj0lNEG1TfgTrIH5vJMbgmoYXWzNHAqBH2e7fncN12p3BP8LFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/mysql": "2.15.26"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql2": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.45.2.tgz",
+      "integrity": "sha512-h6Ad60FjCYdJZ5DTz1Lk2VmQsShiViKe0G7sYikb0GHI0NVvApp2XQNRHNjEMz87roFttGPLHOYVPlfy+yVIhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/sql-common": "^0.40.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.51.1.tgz",
+      "integrity": "sha512-QxgjSrxyWZc7Vk+qGSfsejPVFL1AgAJdSBMYZdDUbwg730D09ub3PXScB9d04vIqPriZ+0dqzjmQx0yWKiCi2Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.26.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/sql-common": "^0.40.1",
+        "@types/pg": "8.6.1",
+        "@types/pg-pool": "2.0.6"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis-4": {
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.46.1.tgz",
+      "integrity": "sha512-UMqleEoabYMsWoTkqyt9WAzXwZ4BlFZHO40wr3d5ZvtjKCHlD4YXLm+6OLCeIi/HkX7EXvQaz8gtAwkwwSEvcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/redis-common": "^0.36.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.18.1.tgz",
+      "integrity": "sha512-5Cuy/nj0HBaH+ZJ4leuD7RjgvA844aY2WW+B5uLcWtxGjRZl3MNLuxnNg5DYWZNPO+NafSSnra0q49KWAHsKBg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/tedious": "^4.0.14"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.10.1.tgz",
+      "integrity": "sha512-rkOGikPEyRpMCmNu9AQuV5dtRlDmJp2dK5sw8roVshAGoB6hH/3QjDtRhdwd75SsJwgynWUNRUYe0wAkTo16tQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
+      }
+    },
+    "node_modules/@opentelemetry/redis-common": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
+      "integrity": "sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
+      "integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sql-common": {
+      "version": "0.40.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.40.1.tgz",
+      "integrity": "sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
+      }
+    },
+    "node_modules/@paulirish/trace_engine": {
+      "version": "0.0.61",
+      "resolved": "https://registry.npmjs.org/@paulirish/trace_engine/-/trace_engine-0.0.61.tgz",
+      "integrity": "sha512-/O08DwmUqIlJjUSPSZbNF8lWnlxaMsIOV6sS+uDKCxBd5i1psAmjEoG3JAqR6+nHD8X+YY474NW7SxUH/K+/kQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "legacy-javascript": "latest",
+        "third-party-web": "latest"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.46.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.1.tgz",
@@ -1677,6 +2322,41 @@
       },
       "bin": {
         "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@prisma/instrumentation": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.11.1.tgz",
+      "integrity": "sha512-mrZOev24EDhnefmnZX7WVVT7v+r9LttPRqf54ONvj6re4XMF7wFTpK2tLJi4XHB7fFp/6xhYbgRel8YV7gQiyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.8"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.0.tgz",
+      "integrity": "sha512-n6oQX6mYkG8TRPuPXmbPidkUbsSRalhmaaVAQxvH1IkQy63cwsH+kOjB3e4cpCDHg0aSvsiX9bQ4s2VB6mGWUQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.3",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
       },
       "engines": {
         "node": ">=18"
@@ -3682,6 +4362,107 @@
         "win32"
       ]
     },
+    "node_modules/@sentry/core": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.47.1.tgz",
+      "integrity": "sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.47.1.tgz",
+      "integrity": "sha512-CDbkasBz3fnWRKSFs6mmaRepM2pa+tbZkrqhPWifFfIkJDidtVW40p6OnquTvPXyPAszCnDZRnZT14xyvNmKPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1",
+        "@opentelemetry/core": "^1.30.1",
+        "@opentelemetry/instrumentation": "^0.57.2",
+        "@opentelemetry/instrumentation-amqplib": "^0.46.1",
+        "@opentelemetry/instrumentation-connect": "0.43.1",
+        "@opentelemetry/instrumentation-dataloader": "0.16.1",
+        "@opentelemetry/instrumentation-express": "0.47.1",
+        "@opentelemetry/instrumentation-fs": "0.19.1",
+        "@opentelemetry/instrumentation-generic-pool": "0.43.1",
+        "@opentelemetry/instrumentation-graphql": "0.47.1",
+        "@opentelemetry/instrumentation-hapi": "0.45.2",
+        "@opentelemetry/instrumentation-http": "0.57.2",
+        "@opentelemetry/instrumentation-ioredis": "0.47.1",
+        "@opentelemetry/instrumentation-kafkajs": "0.7.1",
+        "@opentelemetry/instrumentation-knex": "0.44.1",
+        "@opentelemetry/instrumentation-koa": "0.47.1",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.44.1",
+        "@opentelemetry/instrumentation-mongodb": "0.52.0",
+        "@opentelemetry/instrumentation-mongoose": "0.46.1",
+        "@opentelemetry/instrumentation-mysql": "0.45.1",
+        "@opentelemetry/instrumentation-mysql2": "0.45.2",
+        "@opentelemetry/instrumentation-pg": "0.51.1",
+        "@opentelemetry/instrumentation-redis-4": "0.46.1",
+        "@opentelemetry/instrumentation-tedious": "0.18.1",
+        "@opentelemetry/instrumentation-undici": "0.10.1",
+        "@opentelemetry/resources": "^1.30.1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
+        "@prisma/instrumentation": "6.11.1",
+        "@sentry/core": "9.47.1",
+        "@sentry/node-core": "9.47.1",
+        "@sentry/opentelemetry": "9.47.1",
+        "import-in-the-middle": "^1.14.2",
+        "minimatch": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-9.47.1.tgz",
+      "integrity": "sha512-7TEOiCGkyShJ8CKtsri9lbgMCbB+qNts2Xq37itiMPN2m+lIukK3OX//L8DC5nfKYZlgikrefS63/vJtm669hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "9.47.1",
+        "@sentry/opentelemetry": "9.47.1",
+        "import-in-the-middle": "^1.14.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/resources": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0"
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.47.1.tgz",
+      "integrity": "sha512-STtFpjF7lwzeoedDJV+5XA6P89BfmFwFftmHSGSe3UTI8z8IoiR5yB6X2vCjSPvXlfeOs13qCNNCEZyznxM8Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "9.47.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0"
+      }
+    },
     "node_modules/@shikijs/core": {
       "version": "1.29.2",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.29.2.tgz",
@@ -4171,6 +4952,13 @@
         }
       }
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -4232,6 +5020,16 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/d3": {
@@ -4600,6 +5398,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mysql": {
+      "version": "2.15.26",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
+      "integrity": "sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "24.10.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.3.tgz",
@@ -4608,6 +5416,28 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
+      "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-pool": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
+      "integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "*"
       }
     },
     "node_modules/@types/react": {
@@ -4630,6 +5460,23 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/shimmer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tedious": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -4644,6 +5491,17 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.49.0",
@@ -5176,6 +6034,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -5211,6 +6079,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ansi-escapes": {
@@ -5302,6 +6180,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ast-v8-to-istanbul": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.8.tgz",
@@ -5329,6 +6220,17 @@
       "license": "MIT",
       "bin": {
         "astring": "bin/astring"
+      }
+    },
+    "node_modules/atomically": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.0.tgz",
+      "integrity": "sha512-+gDffFXRW6sl/HCwbta7zK4uNqbPjv4YJEAdz7Vu+FLQHe77eZ4bvbJGi4hE0QPeJlMYMA3piXEr1UL3dAwx7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
       }
     },
     "node_modules/autoprefixer": {
@@ -5369,6 +6271,31 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.0.tgz",
+      "integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -5386,6 +6313,103 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.2.tgz",
+      "integrity": "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
+      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -5416,6 +6440,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/bcp-47-match": {
@@ -5538,6 +6572,16 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/bundle-require": {
@@ -5740,6 +6784,56 @@
       "dev": true,
       "license": "(BSD-3-Clause AND Apache-2.0)"
     },
+    "node_modules/chrome-launcher": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.1.tgz",
+      "integrity": "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^2.0.1"
+      },
+      "bin": {
+        "print-chrome-path": "bin/print-chrome-path.cjs"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-12.0.1.tgz",
+      "integrity": "sha512-fGg+6jr0xjQhzpy5N4ErZxQ4wF7KLEvhGZXD6EgvZKDhu7iOhZXnZhcDxPJDcwTcrD48NPzOCo84RP2lv3Z+Cg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/chromium-bidi/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -5784,6 +6878,84 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clsx": {
@@ -5918,6 +7090,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/configstore": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
+      "integrity": "sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "atomically": "^2.0.3",
+        "dot-prop": "^9.0.0",
+        "graceful-fs": "^4.2.11",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/consola": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
@@ -5989,6 +7180,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csp_evaluator": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/csp_evaluator/-/csp_evaluator-1.1.5.tgz",
+      "integrity": "sha512-EL/iN9etCTzw/fBnp0/uj0f5BOOGvZut2mzsiiBZ/FdT6gFQCKRO/tmcKOxn5drWZ2Ndm/xBb1SI4zwWbGtmIw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/css-selector-parser": {
       "version": "3.2.0",
@@ -6627,6 +7825,16 @@
         "lodash-es": "^4.17.21"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/data-urls": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
@@ -6726,6 +7934,31 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/delaunator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
@@ -6811,6 +8044,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1527314",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1527314.tgz",
+      "integrity": "sha512-UohCFOlzpPPD/IcsxM0k4lVZp/GfhPVJ6l2No5XX+LknpGisPWJe17oOHQhZTHf6ThUFIMwHO6bSEZUq/6oP7w==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/direction": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/direction/-/direction-2.0.1.tgz",
@@ -6840,6 +8080,22 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eastasianwidth": {
@@ -6887,6 +8143,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.18.4",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
@@ -6899,6 +8165,33 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/enquirer/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/entities": {
@@ -7038,6 +8331,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint": {
@@ -7244,6 +8570,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -7431,6 +8771,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -7495,10 +8845,54 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7528,6 +8922,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -7615,6 +9019,13 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -7669,6 +9080,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -7677,6 +9098,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -7713,6 +9144,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/github-slugger": {
@@ -7770,6 +9216,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hast-util-classnames": {
@@ -8223,6 +9682,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-link-header": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.3.tgz",
+      "integrity": "sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -8321,6 +9790,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/image-ssim": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
+      "integrity": "sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -8336,6 +9812,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+      "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
       }
     },
     "node_modules/imurmurhash": {
@@ -8382,6 +9871,29 @@
         "node": ">=12"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
@@ -8408,6 +9920,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-decimal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
@@ -8417,6 +9945,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-extglob": {
@@ -8538,6 +10082,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -8624,6 +10181,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-library-detector": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/js-library-detector/-/js-library-detector-6.7.0.tgz",
+      "integrity": "sha512-c80Qupofp43y4cJ7+8TTDN/AsDwLi5oOm/plBrWI+iQt485vKXCco+yVmOwEgdo9VOdsYTuV0UlTeetVPTriXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/js-tokens": {
@@ -8813,6 +10387,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/legacy-javascript": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/legacy-javascript/-/legacy-javascript-0.0.1.tgz",
+      "integrity": "sha512-lPyntS4/aS7jpuvOlitZDFifBCb4W8L/3QU0PLbUTUj+zYah8rfVjYic88yG7ZKTxhS5h9iz7duT8oUXKszLhg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -8825,6 +10406,88 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lighthouse": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-13.0.1.tgz",
+      "integrity": "sha512-SsxFXPE0DoUv6rH3hva0luh0pbpyIx9McBQ1WUpqCYFMtArODT6l9Zpu1K3XSdkeMQ2/zFcMN5o3pPVhfVwnCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@paulirish/trace_engine": "0.0.61",
+        "@sentry/node": "^9.28.1",
+        "axe-core": "^4.11.0",
+        "chrome-launcher": "^1.2.1",
+        "configstore": "^7.0.0",
+        "csp_evaluator": "1.1.5",
+        "devtools-protocol": "0.0.1527314",
+        "enquirer": "^2.3.6",
+        "http-link-header": "^1.1.1",
+        "intl-messageformat": "^10.5.3",
+        "jpeg-js": "^0.4.4",
+        "js-library-detector": "^6.7.0",
+        "lighthouse-logger": "^2.0.2",
+        "lighthouse-stack-packs": "1.12.3",
+        "lodash-es": "^4.17.21",
+        "lookup-closest-locale": "6.2.0",
+        "open": "^8.4.0",
+        "puppeteer-core": "^24.23.0",
+        "robots-parser": "^3.0.1",
+        "speedline-core": "^1.4.3",
+        "third-party-web": "^0.27.0",
+        "tldts-icann": "^7.0.17",
+        "ws": "^7.0.0",
+        "yargs": "^17.3.1",
+        "yargs-parser": "^21.0.0"
+      },
+      "bin": {
+        "chrome-debug": "core/scripts/manual-chrome-launcher.js",
+        "lighthouse": "cli/index.js",
+        "smokehouse": "cli/test/smokehouse/frontends/smokehouse-bin.js"
+      },
+      "engines": {
+        "node": ">=22.19"
+      }
+    },
+    "node_modules/lighthouse-logger": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.2.tgz",
+      "integrity": "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "marky": "^1.2.2"
+      }
+    },
+    "node_modules/lighthouse-stack-packs": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.12.3.tgz",
+      "integrity": "sha512-d8IsOpE83kbANgnM+Tp8+x6HcMpX9o2ITBiUERssgzAIFdZCQzs/f4k6D0DLQTE59enml9mbAOU52Wu35exWtg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/lighthouse/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/lightningcss": {
@@ -9252,6 +10915,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/lookup-closest-locale": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz",
+      "integrity": "sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -9353,6 +11023,13 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/marky": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/mdast-util-directive": {
       "version": "3.1.0",
@@ -10691,6 +12368,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mlly": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
@@ -10708,6 +12392,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/modern-ahocorasick/-/modern-ahocorasick-1.1.0.tgz",
       "integrity": "sha512-sEKPVl2rM+MNVkGQt3ChdmD8YsigmXdn5NifZn6jiwn9LRJpWm8F3guhaqrJT/JOat6pwpbXEk6kv+b9DMIjsQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
       "dev": true,
       "license": "MIT"
     },
@@ -10777,6 +12468,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/node-releases": {
@@ -10866,6 +12567,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -10892,6 +12603,24 @@
         "emoji-regex-xs": "^1.0.0",
         "regex": "^5.1.1",
         "regex-recursion": "^5.1.1"
+      }
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -11055,6 +12784,40 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/package-manager-detector": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
@@ -11152,12 +12915,60 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -11343,6 +13154,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -11397,6 +13251,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -11408,6 +13272,54 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -11417,6 +13329,32 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.34.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.34.0.tgz",
+      "integrity": "sha512-24evawO+mUGW4mvS2a2ivwLdX3gk8zRLZr9HP+7+VT2vBQnm0oh9jJEZmUE3ePJhRkYlZ93i7OMpdcoi2qNCLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.11.0",
+        "chromium-bidi": "12.0.1",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1534754",
+        "typed-query-selector": "^2.12.0",
+        "webdriver-bidi-protocol": "0.3.10",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/devtools-protocol": {
+      "version": "0.0.1534754",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
+      "integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/radix-ui": {
       "version": "1.4.3",
@@ -12055,6 +13993,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -12065,6 +14013,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/require-like": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/require-like/-/require-like-0.1.2.tgz",
@@ -12072,6 +14035,27 @@
       "dev": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-from": {
@@ -12107,6 +14091,16 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/robots-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-3.0.1.tgz",
+      "integrity": "sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/robust-predicates": {
       "version": "3.0.2",
@@ -12360,6 +14354,13 @@
         "@types/hast": "^3.0.4"
       }
     },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -12417,6 +14418,47 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -12446,6 +14488,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speedline-core": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/speedline-core/-/speedline-core-1.4.3.tgz",
+      "integrity": "sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "image-ssim": "^0.2.0",
+        "jpeg-js": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/stackback": {
@@ -12486,6 +14543,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
       }
     },
     "node_modules/string_decoder": {
@@ -12605,6 +14674,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -12678,6 +14764,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -12713,6 +14812,43 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -12735,6 +14871,13 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/third-party-web": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.27.0.tgz",
+      "integrity": "sha512-h0JYX+dO2Zr3abCQpS6/uFjujaOjA1DyDzGQ41+oFn9VW/ARiq9g5ln7qEP9+BTzDpOMyIfsfj4OvfgXAsMUSA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -12827,6 +14970,16 @@
       "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tldts-icann": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.19.tgz",
+      "integrity": "sha512-PZgda8E2cXMNa7QlBbiZh3vcS8UaPTDRIBmcGPDlujSMtQLrzjvikeJxzQSqWxn3muaMJ7BsC+aL464Yl2I6cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.19"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -13049,6 +15202,26 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -14498,6 +16671,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.3.10.tgz",
+      "integrity": "sha512-5LAE43jAVLOhB/QqX4bwSiv0Hg1HBfMmOuwBSXHdvg4GMGu9Y0lIq7p4R/yySu6w74WmaR4GM4H9t2IwLW7hgw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
@@ -14544,6 +16724,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -14637,6 +16824,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
@@ -14659,6 +16853,19 @@
         }
       }
     },
+    "node_modules/xdg-basedir": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -14675,6 +16882,26 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",
@@ -14697,6 +16924,91 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
       "types": "./dist/playwright/index.d.ts",
       "import": "./dist/playwright/index.js",
       "require": "./dist/playwright/index.cjs"
+    },
+    "./lighthouse": {
+      "types": "./dist/lighthouse/index.d.ts",
+      "import": "./dist/lighthouse/index.js",
+      "require": "./dist/lighthouse/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
@@ -85,6 +90,7 @@
   },
   "peerDependencies": {
     "@playwright/test": "^1.40.0",
+    "lighthouse": ">=11.0.0",
     "react": "^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
@@ -92,6 +98,9 @@
       "optional": true
     },
     "@playwright/test": {
+      "optional": true
+    },
+    "lighthouse": {
       "optional": true
     }
   },
@@ -114,6 +123,7 @@
     "globals": "^16.5.0",
     "husky": "^9.1.7",
     "jsdom": "^27.3.0",
+    "lighthouse": "^13.0.1",
     "lint-staged": "^16.2.7",
     "playwright-core": "1.46.1",
     "prettier": "^3.0.0",

--- a/site/pages/docs/guides/lighthouse.mdx
+++ b/site/pages/docs/guides/lighthouse.mdx
@@ -1,0 +1,361 @@
+# Lighthouse Audits
+
+Run Google Lighthouse audits as part of your Playwright tests.
+
+## Overview
+
+The Lighthouse integration provides a separate `test.lighthouse()` decorator that runs automated page audits and enforces score thresholds. This is completely separate from the `test.performance()` decorator - use whichever suits your testing needs, or both together.
+
+### Key Differences
+
+| Feature | `test.performance()` | `test.lighthouse()` |
+|---------|---------------------|---------------------|
+| Purpose | React Profiler metrics during interactions | Page-level audit at a point in time |
+| Metrics | Duration, rerenders, FPS, memory, Web Vitals | Lighthouse scores (0-100) |
+| When it runs | During test execution | After test function completes |
+| Browser support | Chromium (with graceful degradation) | Chromium only |
+
+## Installation
+
+Install Lighthouse as a dev dependency:
+
+```bash
+npm install -D lighthouse
+```
+
+## Basic Usage
+
+```ts
+import { test as base } from '@playwright/test';
+import { createLighthouseTest } from 'react-performance-tracking/lighthouse';
+
+const test = createLighthouseTest(base);
+
+test.lighthouse({
+  thresholds: {
+    performance: 90,
+    accessibility: 95,
+  },
+})('homepage audit', async ({ page }) => {
+  await page.goto('/');
+  // Lighthouse runs automatically after test function
+});
+```
+
+## Configuration
+
+### Thresholds
+
+Define minimum scores (0-100) for each category:
+
+```ts
+test.lighthouse({
+  thresholds: {
+    performance: 90,
+    accessibility: 95,
+    bestPractices: 90,
+    seo: 80,
+    pwa: 70,
+  },
+})('full audit', async ({ page }) => {
+  await page.goto('/');
+});
+```
+
+| Category | Description |
+|----------|-------------|
+| `performance` | Core Web Vitals, speed metrics |
+| `accessibility` | A11y best practices |
+| `bestPractices` | Modern web best practices |
+| `seo` | Search engine optimization |
+| `pwa` | Progressive Web App requirements |
+
+### Environment-Specific Thresholds
+
+Use different thresholds for CI vs local development:
+
+```ts
+test.lighthouse({
+  thresholds: {
+    base: {
+      performance: 90,
+      accessibility: 95,
+    },
+    ci: {
+      performance: 80, // More lenient in CI
+    },
+  },
+})('homepage', async ({ page }) => {
+  await page.goto('/');
+});
+```
+
+### Throttling
+
+Configure CPU and network throttling:
+
+```ts
+test.lighthouse({
+  throttling: {
+    cpu: 4,                    // CPU slowdown multiplier
+    network: 'fast-3g',        // Network preset
+  },
+  thresholds: {
+    performance: 80,
+  },
+})('mobile simulation', async ({ page }) => {
+  await page.goto('/');
+});
+```
+
+#### Network Presets
+
+| Preset | Latency | Download | Upload |
+|--------|---------|----------|--------|
+| `slow-3g` | 400ms | 500 Kbps | 500 Kbps |
+| `fast-3g` | 150ms | 1.6 Mbps | 750 Kbps |
+| `slow-4g` | 100ms | 3 Mbps | 1.5 Mbps |
+| `fast-4g` | 20ms | 10 Mbps | 5 Mbps |
+
+Or use custom network conditions:
+
+```ts
+throttling: {
+  network: {
+    latencyMs: 100,
+    downloadKbps: 2000,
+    uploadKbps: 1000,
+  },
+}
+```
+
+### Buffers
+
+Add tolerance to thresholds (scores are "higher is better", so buffer is subtractive):
+
+```ts
+test.lighthouse({
+  thresholds: {
+    performance: 90,      // Threshold
+  },
+  buffers: {
+    performance: 5,       // 5% buffer = 90 * 0.95 = 85.5 minimum
+  },
+})('with buffer', async ({ page }) => {
+  await page.goto('/');
+});
+```
+
+:::tip
+Default buffer is 5% for all categories.
+:::
+
+### Form Factor
+
+Choose between mobile and desktop audits:
+
+```ts
+test.lighthouse({
+  formFactor: 'desktop',  // or 'mobile' (default)
+  thresholds: {
+    performance: 90,
+  },
+})('desktop audit', async ({ page }) => {
+  await page.goto('/');
+});
+```
+
+### Warmup Audits
+
+Run a warmup audit before the actual measurement (discarded):
+
+```ts
+test.lighthouse({
+  warmup: true,           // Enabled by default in CI
+  thresholds: {
+    performance: 90,
+  },
+})('with warmup', async ({ page }) => {
+  await page.goto('/');
+});
+```
+
+### Skip Specific Audits
+
+Exclude specific audits from the run:
+
+```ts
+test.lighthouse({
+  skipAudits: ['robots-txt', 'canonical'],
+  thresholds: {
+    seo: 90,
+  },
+})('partial seo audit', async ({ page }) => {
+  await page.goto('/');
+});
+```
+
+### Categories
+
+Only run specific categories:
+
+```ts
+test.lighthouse({
+  categories: ['performance', 'accessibility'],
+  thresholds: {
+    performance: 90,
+    accessibility: 95,
+  },
+})('focused audit', async ({ page }) => {
+  await page.goto('/');
+});
+```
+
+## Full Configuration Example
+
+```ts
+test.lighthouse({
+  // Throttling
+  throttling: {
+    cpu: 4,
+    network: 'fast-3g',
+  },
+
+  // Score thresholds with CI overrides
+  thresholds: {
+    base: {
+      performance: 90,
+      accessibility: 95,
+      bestPractices: 90,
+      seo: 80,
+    },
+    ci: {
+      performance: 80,
+    },
+  },
+
+  // Buffer tolerance
+  buffers: {
+    performance: 5,
+    accessibility: 5,
+  },
+
+  // Audit configuration
+  categories: ['performance', 'accessibility', 'best-practices', 'seo'],
+  formFactor: 'mobile',
+  warmup: true,
+  skipAudits: ['robots-txt'],
+
+  // Custom artifact name
+  name: 'homepage-audit',
+
+})('full audit', async ({ page }) => {
+  await page.goto('/');
+});
+```
+
+## Using Both Decorators
+
+You can use both `test.performance()` and `test.lighthouse()` in the same test file:
+
+```ts
+import { test as base } from '@playwright/test';
+import { createPerformanceTest } from 'react-performance-tracking/playwright';
+import { createLighthouseTest } from 'react-performance-tracking/lighthouse';
+
+const perfTest = createPerformanceTest(base);
+const lhTest = createLighthouseTest(base);
+
+// React Performance Test
+perfTest.performance({
+  throttleRate: 4,
+  thresholds: {
+    base: {
+      profiler: { '*': { duration: 500, rerenders: 20 } },
+      fps: 55,
+    },
+  },
+})('dashboard renders fast', async ({ page, performance }) => {
+  await page.goto('/dashboard');
+  await performance.init();
+});
+
+// Lighthouse Audit Test
+lhTest.lighthouse({
+  throttling: { cpu: 4, network: 'fast-3g' },
+  thresholds: { performance: 90, accessibility: 95 },
+})('dashboard audit', async ({ page }) => {
+  await page.goto('/dashboard');
+});
+```
+
+## Test Results
+
+Lighthouse results are:
+
+1. **Logged to console** with a formatted table showing actual vs threshold scores
+2. **Attached as JSON** to the Playwright test report for later analysis
+
+Example console output:
+
+```
+════════════════════════════════════════════════════════════════════════════════
+ [Performance] PERFORMANCE TEST: lighthouse-homepage-audit
+════════════════════════════════════════════════════════════════════════════════
+ Environment: CI | CPU: 4x | Network: fast-3g
+────────────────────────────────────────────────────────────────────────────────
+
+ GLOBAL METRICS
+┌─────────────────┬────────┬───────────┬────────┐
+│ Metric          │ Actual │ Threshold │ Status │
+├─────────────────┼────────┼───────────┼────────┤
+│ Performance     │     92 │      >= 86│ ✓ PASS │
+│ Accessibility   │     98 │      >= 90│ ✓ PASS │
+└─────────────────┴────────┴───────────┴────────┘
+  URL: http://localhost:3000/
+  Duration: 12.3s
+
+════════════════════════════════════════════════════════════════════════════════
+ ✓ ALL CHECKS PASSED
+════════════════════════════════════════════════════════════════════════════════
+```
+
+## Requirements
+
+- **Chromium browser**: Lighthouse requires Chromium. Non-Chromium browsers will throw an error.
+- **Playwright launched browser**: The browser must be launched by Playwright (not connected to a remote browser).
+- **Lighthouse v11+**: Install as a peer dependency.
+
+## Troubleshooting
+
+### "Lighthouse is not installed"
+
+Install the Lighthouse package:
+
+```bash
+npm install -D lighthouse
+```
+
+### "Lighthouse requires Chromium"
+
+Ensure your Playwright config uses Chromium:
+
+```ts
+// playwright.config.ts
+export default defineConfig({
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});
+```
+
+### "Cannot get browser WebSocket endpoint"
+
+This error occurs when:
+- The browser was connected to remotely (not launched by Playwright)
+- The browser doesn't support the required debugging interface
+
+Ensure you're using `chromium.launch()` (Playwright's default behavior).

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,3 +75,7 @@ export {
   createPerformanceStore,
   updatePerformanceStore,
 } from './react';
+
+// Lighthouse
+export { createLighthouseTest, type LighthouseTest } from './lighthouse';
+export type { LighthouseMetrics, LighthouseTestConfig, LighthouseThresholds } from './lighthouse';

--- a/src/lighthouse/LighthouseTestRunner.ts
+++ b/src/lighthouse/LighthouseTestRunner.ts
@@ -1,0 +1,153 @@
+import type { Browser, Page } from '@playwright/test';
+
+import { createLogger } from '../utils';
+
+import { assertLighthouseThresholds, attachLighthouseResults } from './lighthouseAssertions';
+import { formatThrottling, mapToLighthouseThrottling } from './lighthouseConfig';
+import type {
+  ConfiguredLighthouseTestInfo,
+  LighthouseMetrics,
+  LighthouseTestFixtures,
+  LighthouseTestFunction,
+} from './types';
+
+const logger = createLogger('Lighthouse');
+
+async function isLighthouseAvailable(): Promise<boolean> {
+  try {
+    await import('lighthouse');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Extended Browser type that includes wsEndpoint() method.
+ * The wsEndpoint is available at runtime when using chromium.launch()
+ * but TypeScript's public API doesn't expose it.
+ */
+type BrowserWithWsEndpoint = Browser & {
+  wsEndpoint(): string;
+};
+
+/**
+ * Orchestrates Lighthouse test execution.
+ * Simpler than PerformanceTestRunner - single audit, no iterations.
+ */
+export class LighthouseTestRunner {
+  constructor(
+    private readonly page: Page,
+    private readonly fixtures: LighthouseTestFixtures,
+    private readonly testInfo: ConfiguredLighthouseTestInfo,
+  ) {}
+
+  async execute(testFn: LighthouseTestFunction): Promise<void> {
+    this.validateBrowser();
+
+    if (!(await isLighthouseAvailable())) {
+      throw new Error('Lighthouse is not installed. Run: npm install -D lighthouse');
+    }
+
+    // Execute test function (user navigates to page)
+    await testFn(this.fixtures, this.testInfo);
+
+    // Warmup audit if enabled
+    if (this.testInfo.warmup) {
+      logger.info('Running warmup audit...');
+      try {
+        await this.runAudit();
+      } catch (e) {
+        logger.warn('Warmup failed, continuing:', e);
+      }
+    }
+
+    // Actual audit
+    const metrics = await this.runAudit();
+
+    // Assert and attach
+    let error: Error | null = null;
+    try {
+      assertLighthouseThresholds({ metrics, testInfo: this.testInfo });
+    } catch (e) {
+      error = e as Error;
+    }
+
+    try {
+      await attachLighthouseResults(this.testInfo, metrics);
+    } catch (e) {
+      logger.warn('Failed to attach results:', e);
+    }
+
+    if (error) throw error;
+  }
+
+  private validateBrowser(): void {
+    const browserName = this.page.context().browser()?.browserType().name();
+    if (browserName !== 'chromium') {
+      throw new Error(`Lighthouse requires Chromium. Current: ${browserName ?? 'unknown'}`);
+    }
+  }
+
+  private async runAudit(): Promise<LighthouseMetrics> {
+    const { throttling, categories, formFactor, skipAudits } = this.testInfo;
+    const url = this.page.url();
+
+    logger.info(`Auditing ${url}...`);
+    logger.info(`Throttling: ${formatThrottling(throttling.cpu, throttling.network)}`);
+
+    const lighthouse = (await import('lighthouse')).default;
+    const browser = this.page.context().browser() as BrowserWithWsEndpoint | null;
+
+    if (!browser || typeof browser.wsEndpoint !== 'function') {
+      throw new Error(
+        'Cannot get browser WebSocket endpoint. ' +
+          'Ensure the browser is launched with Playwright (not connected to a remote browser).',
+      );
+    }
+
+    const port = parseInt(new URL(browser.wsEndpoint()).port, 10);
+
+    const lhThrottling = mapToLighthouseThrottling(throttling.cpu, throttling.network);
+
+    const startTime = Date.now();
+    const result = await lighthouse(url, {
+      port,
+      output: 'json',
+      onlyCategories: categories,
+      skipAudits: skipAudits.length > 0 ? skipAudits : undefined,
+      formFactor,
+      throttling: lhThrottling,
+      disableStorageReset: true,
+    });
+
+    if (!result?.lhr) {
+      throw new Error('Lighthouse returned no results');
+    }
+
+    const { categories: cats } = result.lhr;
+    const metrics: LighthouseMetrics = {
+      performance: this.extractScore(cats.performance),
+      accessibility: this.extractScore(cats.accessibility),
+      bestPractices: this.extractScore(cats['best-practices']),
+      seo: this.extractScore(cats.seo),
+      pwa: this.extractScore(cats.pwa),
+      auditDurationMs: Date.now() - startTime,
+      url: result.lhr.finalDisplayedUrl || url,
+      timestamp: new Date().toISOString(),
+    };
+
+    logger.info(
+      `Completed in ${(metrics.auditDurationMs / 1000).toFixed(1)}s: ` +
+        `Perf=${metrics.performance ?? 'N/A'}, A11y=${metrics.accessibility ?? 'N/A'}`,
+    );
+
+    return metrics;
+  }
+
+  private extractScore(category?: { score: number | null }): number | null {
+    return category?.score !== null && category?.score !== undefined
+      ? Math.round(category.score * 100)
+      : null;
+  }
+}

--- a/src/lighthouse/createLighthouseTest.ts
+++ b/src/lighthouse/createLighthouseTest.ts
@@ -1,0 +1,38 @@
+import type { TestType } from '@playwright/test';
+
+import { createConfiguredTestInfo } from './lighthouseConfig';
+import { LighthouseTestRunner } from './LighthouseTestRunner';
+import type { LighthouseTestConfig, LighthouseTestFixtures, LighthouseTestFunction } from './types';
+
+/**
+ * Type for the extended test with lighthouse method
+ */
+export type LighthouseTest<T extends LighthouseTestFixtures, W extends object = object> = TestType<
+  T,
+  W
+> & {
+  lighthouse: (
+    config: LighthouseTestConfig,
+  ) => (title: string, testFn: LighthouseTestFunction) => ReturnType<TestType<T, W>>;
+};
+
+/**
+ * Extends a Playwright test with the `lighthouse` method.
+ * Unlike performance tests, lighthouse tests don't need custom fixtures.
+ */
+export function createLighthouseTest<T extends LighthouseTestFixtures, W extends object = object>(
+  baseTest: TestType<T, W>,
+): LighthouseTest<T, W> {
+  const lighthouse = (config: LighthouseTestConfig) => {
+    return (title: string, testFn: LighthouseTestFunction) => {
+      return baseTest(title, async ({ page }, testInfo) => {
+        const configured = createConfiguredTestInfo(testInfo, config, title);
+        const fixtures: LighthouseTestFixtures = { page };
+        const runner = new LighthouseTestRunner(page, fixtures, configured);
+        await runner.execute(testFn);
+      });
+    };
+  };
+
+  return Object.assign(baseTest, { lighthouse }) as LighthouseTest<T, W>;
+}

--- a/src/lighthouse/index.ts
+++ b/src/lighthouse/index.ts
@@ -1,0 +1,39 @@
+// Factory
+export { createLighthouseTest, type LighthouseTest } from './createLighthouseTest';
+
+// Runner
+export { LighthouseTestRunner } from './LighthouseTestRunner';
+
+// Config
+export {
+  createConfiguredTestInfo,
+  formatThrottling,
+  mapToLighthouseThrottling,
+  resolveBuffers,
+  resolveConfig,
+  resolveThresholds,
+  type LighthouseThrottlingSettings,
+} from './lighthouseConfig';
+
+// Assertions
+export { assertLighthouseThresholds, attachLighthouseResults } from './lighthouseAssertions';
+
+// Types
+export type {
+  ConfiguredLighthouseTestInfo,
+  LighthouseBufferConfig,
+  LighthouseCategoryId,
+  LighthouseMetrics,
+  LighthouseNetworkConditions,
+  LighthouseNetworkThrottling,
+  LighthouseScore,
+  LighthouseTestConfig,
+  LighthouseTestFixtures,
+  LighthouseTestFunction,
+  LighthouseThresholdConfig,
+  LighthouseThresholds,
+  LighthouseThrottlingConfig,
+  ResolvedLighthouseBufferConfig,
+  ResolvedLighthouseTestConfig,
+  ResolvedLighthouseThresholds,
+} from './types';

--- a/src/lighthouse/lighthouseAssertions.ts
+++ b/src/lighthouse/lighthouseAssertions.ts
@@ -1,0 +1,135 @@
+import { expect } from '@playwright/test';
+
+import { PERFORMANCE_CONFIG } from '../playwright/config/performanceConfig';
+import {
+  logGlobalMetricsTable,
+  logTestFooter,
+  logTestHeader,
+  type MetricRow,
+} from '../playwright/assertions/logging';
+import { calculateEffectiveMinThreshold } from '../playwright/utils/thresholdCalculator';
+
+import type {
+  ConfiguredLighthouseTestInfo,
+  LighthouseMetrics,
+  LighthouseScore,
+  ResolvedLighthouseThresholds,
+} from './types';
+
+const CATEGORY_NAMES: Record<string, string> = {
+  performance: 'Performance',
+  accessibility: 'Accessibility',
+  bestPractices: 'Best Practices',
+  seo: 'SEO',
+  pwa: 'PWA',
+};
+
+type AssertParams = {
+  metrics: LighthouseMetrics;
+  testInfo: ConfiguredLighthouseTestInfo;
+};
+
+/**
+ * Creates a MetricRow for a Lighthouse score (higher is better).
+ * Reuses the same pattern as createFPSMetricRow from logging.ts.
+ */
+function createScoreMetricRow(
+  name: string,
+  actual: LighthouseScore,
+  threshold: LighthouseScore,
+  bufferPercent: number,
+): MetricRow {
+  const effective = calculateEffectiveMinThreshold(threshold, bufferPercent);
+  const passed = actual >= effective;
+  return {
+    name,
+    actual: String(actual),
+    threshold: `>= ${effective.toFixed(0)}`,
+    passed,
+  };
+}
+
+/**
+ * Asserts all configured Lighthouse thresholds.
+ */
+export function assertLighthouseThresholds({ metrics, testInfo }: AssertParams): void {
+  const { thresholds, buffers, throttling, warmup, name } = testInfo;
+
+  // Log header using shared utility
+  logTestHeader({
+    testName: name,
+    throttleRate: throttling.cpu,
+    warmup,
+    networkThrottling: typeof throttling.network === 'string' ? throttling.network : undefined,
+  });
+
+  // Build metric rows
+  const rows: MetricRow[] = [];
+  const categories: Array<{
+    key: keyof ResolvedLighthouseThresholds;
+    actual: LighthouseScore | null;
+  }> = [
+    { key: 'performance', actual: metrics.performance },
+    { key: 'accessibility', actual: metrics.accessibility },
+    { key: 'bestPractices', actual: metrics.bestPractices },
+    { key: 'seo', actual: metrics.seo },
+    { key: 'pwa', actual: metrics.pwa },
+  ];
+
+  for (const { key, actual } of categories) {
+    const threshold = thresholds[key];
+    if (threshold > 0 && actual !== null) {
+      rows.push(createScoreMetricRow(CATEGORY_NAMES[key] ?? key, actual, threshold, buffers[key]));
+    }
+  }
+
+  // Log results table using shared utility
+  logGlobalMetricsTable(rows);
+
+  // Log URL and duration
+  console.log(`  URL: ${metrics.url}`);
+  console.log(`  Duration: ${(metrics.auditDurationMs / 1000).toFixed(1)}s`);
+
+  // Count pass/fail
+  const passedCount = rows.filter((r) => r.passed).length;
+  logTestFooter(passedCount, rows.length);
+
+  // Run actual assertions
+  for (const { key, actual } of categories) {
+    const threshold = thresholds[key];
+    if (threshold > 0 && actual !== null) {
+      const effective = calculateEffectiveMinThreshold(threshold, buffers[key]);
+      const displayName = CATEGORY_NAMES[key] ?? key;
+
+      expect(
+        actual,
+        `Lighthouse ${displayName} should be >= ${effective.toFixed(0)} ` +
+          `(actual: ${actual}, threshold: ${threshold} - ${buffers[key]}% buffer)`,
+      ).toBeGreaterThanOrEqual(effective);
+    }
+  }
+}
+
+/**
+ * Attaches Lighthouse results as JSON artifact.
+ */
+export async function attachLighthouseResults(
+  testInfo: ConfiguredLighthouseTestInfo,
+  metrics: LighthouseMetrics,
+): Promise<void> {
+  const data = {
+    metrics,
+    throttling: testInfo.throttling,
+    thresholds: testInfo.thresholds,
+    buffers: testInfo.buffers,
+    categories: testInfo.categories,
+    formFactor: testInfo.formFactor,
+    warmup: testInfo.warmup,
+    environment: PERFORMANCE_CONFIG.isCI ? 'ci' : 'local',
+  };
+
+  await testInfo.attach(testInfo.name, {
+    body: JSON.stringify(data, null, 2),
+    contentType: 'application/json',
+  });
+}

--- a/src/lighthouse/lighthouseConfig.ts
+++ b/src/lighthouse/lighthouseConfig.ts
@@ -1,0 +1,169 @@
+import type { TestInfo } from '@playwright/test';
+
+import { PERFORMANCE_CONFIG } from '../playwright/config/performanceConfig';
+import { NETWORK_PRESETS, type NetworkPreset } from '../playwright/features';
+
+import type {
+  ConfiguredLighthouseTestInfo,
+  LighthouseBufferConfig,
+  LighthouseCategoryId,
+  LighthouseNetworkThrottling,
+  LighthouseTestConfig,
+  LighthouseThresholdConfig,
+  LighthouseThresholds,
+  ResolvedLighthouseBufferConfig,
+  ResolvedLighthouseTestConfig,
+  ResolvedLighthouseThresholds,
+} from './types';
+
+// ============================================
+// Defaults
+// ============================================
+
+const DEFAULT_CPU_THROTTLE = 4;
+const DEFAULT_NETWORK_PRESET: NetworkPreset = 'fast-4g';
+const DEFAULT_BUFFER_PERCENT = 5;
+
+const DEFAULT_CATEGORIES: LighthouseCategoryId[] = [
+  'performance',
+  'accessibility',
+  'best-practices',
+  'seo',
+];
+
+const DEFAULT_THRESHOLDS: ResolvedLighthouseThresholds = {
+  performance: 0,
+  accessibility: 0,
+  bestPractices: 0,
+  seo: 0,
+  pwa: 0,
+};
+
+const DEFAULT_BUFFERS: ResolvedLighthouseBufferConfig = {
+  performance: DEFAULT_BUFFER_PERCENT,
+  accessibility: DEFAULT_BUFFER_PERCENT,
+  bestPractices: DEFAULT_BUFFER_PERCENT,
+  seo: DEFAULT_BUFFER_PERCENT,
+  pwa: DEFAULT_BUFFER_PERCENT,
+};
+
+// ============================================
+// Resolution Functions
+// ============================================
+
+function isShorthandThresholds(
+  thresholds: LighthouseThresholds | LighthouseThresholdConfig,
+): thresholds is LighthouseThresholds {
+  return !('base' in thresholds);
+}
+
+export function resolveThresholds(
+  config: LighthouseThresholds | LighthouseThresholdConfig,
+): ResolvedLighthouseThresholds {
+  const normalized = isShorthandThresholds(config) ? { base: config } : config;
+  const merged = PERFORMANCE_CONFIG.isCI
+    ? { ...normalized.base, ...normalized.ci }
+    : normalized.base;
+
+  return {
+    performance: merged.performance ?? DEFAULT_THRESHOLDS.performance,
+    accessibility: merged.accessibility ?? DEFAULT_THRESHOLDS.accessibility,
+    bestPractices: merged.bestPractices ?? DEFAULT_THRESHOLDS.bestPractices,
+    seo: merged.seo ?? DEFAULT_THRESHOLDS.seo,
+    pwa: merged.pwa ?? DEFAULT_THRESHOLDS.pwa,
+  };
+}
+
+export function resolveBuffers(buffers?: LighthouseBufferConfig): ResolvedLighthouseBufferConfig {
+  return {
+    performance: buffers?.performance ?? DEFAULT_BUFFERS.performance,
+    accessibility: buffers?.accessibility ?? DEFAULT_BUFFERS.accessibility,
+    bestPractices: buffers?.bestPractices ?? DEFAULT_BUFFERS.bestPractices,
+    seo: buffers?.seo ?? DEFAULT_BUFFERS.seo,
+    pwa: buffers?.pwa ?? DEFAULT_BUFFERS.pwa,
+  };
+}
+
+function generateArtifactName(title: string): string {
+  return `lighthouse-${title
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')}`;
+}
+
+export function resolveConfig(
+  config: LighthouseTestConfig,
+  testTitle: string,
+): ResolvedLighthouseTestConfig {
+  return {
+    throttling: {
+      cpu: config.throttling?.cpu ?? DEFAULT_CPU_THROTTLE,
+      network: config.throttling?.network ?? DEFAULT_NETWORK_PRESET,
+    },
+    thresholds: resolveThresholds(config.thresholds),
+    buffers: resolveBuffers(config.buffers),
+    categories: config.categories ?? DEFAULT_CATEGORIES,
+    formFactor: config.formFactor ?? 'mobile',
+    warmup: config.warmup ?? PERFORMANCE_CONFIG.isCI,
+    name: config.name ?? generateArtifactName(testTitle),
+    skipAudits: config.skipAudits ?? [],
+  };
+}
+
+export function createConfiguredTestInfo(
+  testInfo: TestInfo,
+  config: LighthouseTestConfig,
+  testTitle: string,
+): ConfiguredLighthouseTestInfo {
+  const resolved = resolveConfig(config, testTitle);
+  const configured = Object.create(testInfo) as ConfiguredLighthouseTestInfo;
+  Object.assign(configured, resolved);
+  return configured;
+}
+
+// ============================================
+// Throttling Mapping (Reuses NETWORK_PRESETS)
+// ============================================
+
+export interface LighthouseThrottlingSettings {
+  cpuSlowdownMultiplier: number;
+  requestLatencyMs: number;
+  downloadThroughputKbps: number;
+  uploadThroughputKbps: number;
+  rttMs: number;
+}
+
+function isNetworkPreset(network: LighthouseNetworkThrottling): network is NetworkPreset {
+  return typeof network === 'string' && network in NETWORK_PRESETS;
+}
+
+export function mapToLighthouseThrottling(
+  cpu: number,
+  network: LighthouseNetworkThrottling,
+): LighthouseThrottlingSettings {
+  if (isNetworkPreset(network)) {
+    const preset = NETWORK_PRESETS[network];
+    return {
+      cpuSlowdownMultiplier: cpu,
+      requestLatencyMs: preset.latency,
+      // Convert bytes/sec to Kbps: (bytes/s * 8) / 1024
+      downloadThroughputKbps: (preset.downloadThroughput * 8) / 1024,
+      uploadThroughputKbps: (preset.uploadThroughput * 8) / 1024,
+      rttMs: preset.latency,
+    };
+  }
+
+  // Custom network conditions (already in Kbps)
+  return {
+    cpuSlowdownMultiplier: cpu,
+    requestLatencyMs: network.latencyMs,
+    downloadThroughputKbps: network.downloadKbps,
+    uploadThroughputKbps: network.uploadKbps,
+    rttMs: network.latencyMs,
+  };
+}
+
+export function formatThrottling(cpu: number, network: LighthouseNetworkThrottling): string {
+  const networkStr = typeof network === 'string' ? network : `${network.downloadKbps}Kbps`;
+  return `CPU ${cpu}x, Network: ${networkStr}`;
+}

--- a/src/lighthouse/types.ts
+++ b/src/lighthouse/types.ts
@@ -1,0 +1,124 @@
+import type { Page, TestInfo } from '@playwright/test';
+
+import type { NetworkPreset } from '../playwright/features';
+
+// ============================================
+// Score & Metric Types
+// ============================================
+
+/** Lighthouse score (0-100) */
+export type LighthouseScore = number;
+
+/** Lighthouse audit category identifiers */
+export type LighthouseCategoryId =
+  | 'performance'
+  | 'accessibility'
+  | 'best-practices'
+  | 'seo'
+  | 'pwa';
+
+/** Lighthouse audit results */
+export type LighthouseMetrics = {
+  performance: LighthouseScore | null;
+  accessibility: LighthouseScore | null;
+  bestPractices: LighthouseScore | null;
+  seo: LighthouseScore | null;
+  pwa: LighthouseScore | null;
+  auditDurationMs: number;
+  url: string;
+  timestamp: string;
+};
+
+// ============================================
+// Throttling Types (Reuses NetworkPreset)
+// ============================================
+
+/** Custom network conditions for Lighthouse */
+export type LighthouseNetworkConditions = {
+  latencyMs: number;
+  downloadKbps: number;
+  uploadKbps: number;
+};
+
+/** Network throttling - reuses existing presets or custom */
+export type LighthouseNetworkThrottling = NetworkPreset | LighthouseNetworkConditions;
+
+/** Throttling configuration */
+export type LighthouseThrottlingConfig = {
+  cpu?: number;
+  network?: LighthouseNetworkThrottling;
+};
+
+// ============================================
+// Threshold Types
+// ============================================
+
+export type LighthouseThresholds = {
+  performance?: LighthouseScore;
+  accessibility?: LighthouseScore;
+  bestPractices?: LighthouseScore;
+  seo?: LighthouseScore;
+  pwa?: LighthouseScore;
+};
+
+export type ResolvedLighthouseThresholds = Required<LighthouseThresholds>;
+
+export type LighthouseThresholdConfig = {
+  base: LighthouseThresholds;
+  ci?: Partial<LighthouseThresholds>;
+};
+
+// ============================================
+// Buffer Types
+// ============================================
+
+export type LighthouseBufferConfig = {
+  performance?: number;
+  accessibility?: number;
+  bestPractices?: number;
+  seo?: number;
+  pwa?: number;
+};
+
+export type ResolvedLighthouseBufferConfig = Required<LighthouseBufferConfig>;
+
+// ============================================
+// Test Configuration
+// ============================================
+
+export type LighthouseTestConfig = {
+  throttling?: LighthouseThrottlingConfig;
+  thresholds: LighthouseThresholds | LighthouseThresholdConfig;
+  buffers?: LighthouseBufferConfig;
+  categories?: LighthouseCategoryId[];
+  formFactor?: 'mobile' | 'desktop';
+  warmup?: boolean;
+  name?: string;
+  skipAudits?: string[];
+};
+
+export type ResolvedLighthouseTestConfig = {
+  throttling: Required<LighthouseThrottlingConfig>;
+  thresholds: ResolvedLighthouseThresholds;
+  buffers: ResolvedLighthouseBufferConfig;
+  categories: LighthouseCategoryId[];
+  formFactor: 'mobile' | 'desktop';
+  warmup: boolean;
+  name: string;
+  skipAudits: string[];
+};
+
+// ============================================
+// Test Function Types
+// ============================================
+
+export type LighthouseTestFixtures = {
+  page: Page;
+};
+
+export type LighthouseTestFunction = (
+  fixtures: LighthouseTestFixtures,
+  testInfo: ConfiguredLighthouseTestInfo,
+) => Promise<void> | void;
+
+export type ConfiguredLighthouseTestInfo = TestInfo & ResolvedLighthouseTestConfig;

--- a/tests/integration/e2e-lighthouse.spec.ts
+++ b/tests/integration/e2e-lighthouse.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test as base } from '@playwright/test';
+
+import { createLighthouseTest } from '@lib/lighthouse';
+
+// Create lighthouse-enabled test
+const test = createLighthouseTest(base);
+
+// Helper to build scenario URL
+const scenario = (name: string) => `/?scenario=${name}`;
+
+test.describe('E2E Lighthouse Tests', () => {
+  test.describe('Lighthouse test factory', () => {
+    test('should have lighthouse method on test object', () => {
+      expect(test.lighthouse).toBeDefined();
+      expect(typeof test.lighthouse).toBe('function');
+    });
+
+    test('should create a test with lighthouse decorator', async ({ page }) => {
+      await page.goto(scenario('basic-profiler'));
+
+      // Just verify the page loads - we're testing the factory works
+      const title = await page.title();
+      expect(title).toBeDefined();
+    });
+  });
+
+  // NOTE: The actual lighthouse audit tests are skipped by default because:
+  // 1. They require Chromium browser only
+  // 2. They take 15-30 seconds per audit
+  // 3. They require real network access
+  // To run these tests, use: npx playwright test e2e-lighthouse --headed
+  test.describe.skip('Lighthouse audit tests (slow)', () => {
+    test.lighthouse({
+      throttling: { cpu: 4, network: 'fast-4g' },
+      thresholds: {
+        performance: 50,
+        accessibility: 50,
+      },
+      warmup: false,
+    })('should run lighthouse audit on test app', async ({ page }) => {
+      await page.goto(scenario('basic-profiler'));
+      // Lighthouse audit runs automatically after test function
+    });
+  });
+});

--- a/tests/unit/lighthouse/lighthouseAssertions.test.ts
+++ b/tests/unit/lighthouse/lighthouseAssertions.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ConfiguredLighthouseTestInfo, LighthouseMetrics } from '@lib/lighthouse/types';
+
+// Mock dependencies before importing
+vi.mock('@lib/playwright/assertions/logging', () => ({
+  logTestHeader: vi.fn(),
+  logTestFooter: vi.fn(),
+  logGlobalMetricsTable: vi.fn(),
+}));
+
+vi.mock('@lib/playwright/config/performanceConfig', () => ({
+  PERFORMANCE_CONFIG: {
+    isCI: false,
+  },
+}));
+
+// Import after mocks are set up
+import {
+  assertLighthouseThresholds,
+  attachLighthouseResults,
+} from '@lib/lighthouse/lighthouseAssertions';
+
+describe('assertLighthouseThresholds', () => {
+  const mockTestInfo = {
+    title: 'test',
+    attach: vi.fn().mockResolvedValue(undefined),
+    thresholds: {
+      performance: 90,
+      accessibility: 95,
+      bestPractices: 0,
+      seo: 0,
+      pwa: 0,
+    },
+    buffers: {
+      performance: 5,
+      accessibility: 5,
+      bestPractices: 5,
+      seo: 5,
+      pwa: 5,
+    },
+    throttling: {
+      cpu: 4,
+      network: 'fast-4g' as const,
+    },
+    warmup: false,
+    name: 'lighthouse-test',
+    categories: ['performance', 'accessibility'] as const,
+    formFactor: 'mobile' as const,
+    skipAudits: [],
+  } as unknown as ConfiguredLighthouseTestInfo;
+
+  const mockMetrics: LighthouseMetrics = {
+    performance: 95,
+    accessibility: 98,
+    bestPractices: 90,
+    seo: 85,
+    pwa: null,
+    auditDurationMs: 15000,
+    url: 'http://localhost:3000',
+    timestamp: '2025-01-01T00:00:00Z',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should pass when scores meet thresholds', () => {
+    expect(() =>
+      assertLighthouseThresholds({
+        metrics: mockMetrics,
+        testInfo: mockTestInfo,
+      }),
+    ).not.toThrow();
+  });
+
+  it('should fail when performance score is below threshold', () => {
+    const lowScoreMetrics: LighthouseMetrics = {
+      ...mockMetrics,
+      performance: 80, // Below 90 - 5% buffer = 85.5
+    };
+
+    expect(() =>
+      assertLighthouseThresholds({
+        metrics: lowScoreMetrics,
+        testInfo: mockTestInfo,
+      }),
+    ).toThrow(/Expected: >= 85\.5/);
+  });
+
+  it('should pass when score is at buffer boundary', () => {
+    const boundaryMetrics: LighthouseMetrics = {
+      ...mockMetrics,
+      performance: 86, // Exactly at 90 - 5% = 85.5, rounded up to 86
+    };
+
+    expect(() =>
+      assertLighthouseThresholds({
+        metrics: boundaryMetrics,
+        testInfo: mockTestInfo,
+      }),
+    ).not.toThrow();
+  });
+
+  it('should skip categories with threshold of 0', () => {
+    const metricsWithLowSeo: LighthouseMetrics = {
+      ...mockMetrics,
+      seo: 20, // Very low, but threshold is 0 so should be skipped
+    };
+
+    expect(() =>
+      assertLighthouseThresholds({
+        metrics: metricsWithLowSeo,
+        testInfo: mockTestInfo,
+      }),
+    ).not.toThrow();
+  });
+
+  it('should skip categories with null score', () => {
+    const testInfoWithPwa = {
+      ...mockTestInfo,
+      thresholds: {
+        ...mockTestInfo.thresholds,
+        pwa: 80, // Set threshold but score is null
+      },
+    } as unknown as ConfiguredLighthouseTestInfo;
+
+    // pwa is null in mockMetrics, should be skipped
+    expect(() =>
+      assertLighthouseThresholds({
+        metrics: mockMetrics,
+        testInfo: testInfoWithPwa,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe('attachLighthouseResults', () => {
+  const mockTestInfo = {
+    attach: vi.fn().mockResolvedValue(undefined),
+    thresholds: {
+      performance: 90,
+      accessibility: 95,
+      bestPractices: 0,
+      seo: 0,
+      pwa: 0,
+    },
+    buffers: {
+      performance: 5,
+      accessibility: 5,
+      bestPractices: 5,
+      seo: 5,
+      pwa: 5,
+    },
+    throttling: {
+      cpu: 4,
+      network: 'fast-4g',
+    },
+    warmup: false,
+    name: 'lighthouse-test',
+    categories: ['performance', 'accessibility'],
+    formFactor: 'mobile',
+    skipAudits: [],
+  } as unknown as ConfiguredLighthouseTestInfo;
+
+  const mockMetrics: LighthouseMetrics = {
+    performance: 95,
+    accessibility: 98,
+    bestPractices: 90,
+    seo: 85,
+    pwa: null,
+    auditDurationMs: 15000,
+    url: 'http://localhost:3000',
+    timestamp: '2025-01-01T00:00:00Z',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should attach results as JSON', async () => {
+    await attachLighthouseResults(mockTestInfo, mockMetrics);
+
+    expect(mockTestInfo.attach).toHaveBeenCalledWith(
+      'lighthouse-test',
+      expect.objectContaining({
+        contentType: 'application/json',
+      }),
+    );
+  });
+
+  it('should include metrics in attachment', async () => {
+    await attachLighthouseResults(mockTestInfo, mockMetrics);
+
+    const attachCall = mockTestInfo.attach.mock.calls[0];
+    const body = JSON.parse(attachCall[1].body);
+
+    expect(body.metrics).toEqual(mockMetrics);
+    expect(body.throttling).toEqual(mockTestInfo.throttling);
+    expect(body.thresholds).toEqual(mockTestInfo.thresholds);
+    expect(body.environment).toBe('local');
+  });
+});

--- a/tests/unit/lighthouse/lighthouseConfig.test.ts
+++ b/tests/unit/lighthouse/lighthouseConfig.test.ts
@@ -1,0 +1,302 @@
+import type { TestInfo } from '@playwright/test';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createConfiguredTestInfo,
+  formatThrottling,
+  mapToLighthouseThrottling,
+  resolveBuffers,
+  resolveConfig,
+  resolveThresholds,
+} from '@lib/lighthouse/lighthouseConfig';
+import type { LighthouseTestConfig, LighthouseThresholds } from '@lib/lighthouse/types';
+
+// Mock PERFORMANCE_CONFIG.isCI
+vi.mock('@lib/playwright/config/performanceConfig', () => ({
+  PERFORMANCE_CONFIG: {
+    get isCI(): boolean {
+      return false;
+    },
+  },
+}));
+
+describe('resolveThresholds', () => {
+  describe('shorthand format', () => {
+    it('should resolve shorthand thresholds with defaults', () => {
+      const thresholds: LighthouseThresholds = {
+        performance: 90,
+        accessibility: 95,
+      };
+
+      const result = resolveThresholds(thresholds);
+
+      expect(result.performance).toBe(90);
+      expect(result.accessibility).toBe(95);
+      expect(result.bestPractices).toBe(0);
+      expect(result.seo).toBe(0);
+      expect(result.pwa).toBe(0);
+    });
+
+    it('should handle all categories specified', () => {
+      const thresholds: LighthouseThresholds = {
+        performance: 90,
+        accessibility: 95,
+        bestPractices: 85,
+        seo: 80,
+        pwa: 70,
+      };
+
+      const result = resolveThresholds(thresholds);
+
+      expect(result.performance).toBe(90);
+      expect(result.accessibility).toBe(95);
+      expect(result.bestPractices).toBe(85);
+      expect(result.seo).toBe(80);
+      expect(result.pwa).toBe(70);
+    });
+
+    it('should handle empty thresholds', () => {
+      const result = resolveThresholds({});
+
+      expect(result.performance).toBe(0);
+      expect(result.accessibility).toBe(0);
+      expect(result.bestPractices).toBe(0);
+      expect(result.seo).toBe(0);
+      expect(result.pwa).toBe(0);
+    });
+  });
+
+  describe('base/ci format', () => {
+    it('should use base thresholds in non-CI environment', () => {
+      const result = resolveThresholds({
+        base: { performance: 90, accessibility: 95 },
+        ci: { performance: 80 },
+      });
+
+      expect(result.performance).toBe(90);
+      expect(result.accessibility).toBe(95);
+    });
+
+    // NOTE: Testing CI environment merge is better done in integration tests
+    // because mocking the module-level import is complex with ESM
+    it('should handle ci config even when not in CI', () => {
+      // Just verifying the structure is parsed correctly
+      const result = resolveThresholds({
+        base: { performance: 90, accessibility: 95 },
+        ci: { performance: 80 },
+      });
+
+      // In non-CI (mocked), should use base values
+      expect(result.performance).toBe(90);
+      expect(result.accessibility).toBe(95);
+    });
+  });
+});
+
+describe('resolveBuffers', () => {
+  it('should use default buffers when none provided', () => {
+    const result = resolveBuffers();
+
+    expect(result.performance).toBe(5);
+    expect(result.accessibility).toBe(5);
+    expect(result.bestPractices).toBe(5);
+    expect(result.seo).toBe(5);
+    expect(result.pwa).toBe(5);
+  });
+
+  it('should override specific buffers', () => {
+    const result = resolveBuffers({
+      performance: 10,
+      accessibility: 3,
+    });
+
+    expect(result.performance).toBe(10);
+    expect(result.accessibility).toBe(3);
+    expect(result.bestPractices).toBe(5);
+    expect(result.seo).toBe(5);
+    expect(result.pwa).toBe(5);
+  });
+
+  it('should allow zero buffer', () => {
+    const result = resolveBuffers({
+      performance: 0,
+    });
+
+    expect(result.performance).toBe(0);
+  });
+});
+
+describe('resolveConfig', () => {
+  it('should resolve minimal config with defaults', () => {
+    const config: LighthouseTestConfig = {
+      thresholds: { performance: 90 },
+    };
+
+    const result = resolveConfig(config, 'my test');
+
+    expect(result.throttling.cpu).toBe(4);
+    expect(result.throttling.network).toBe('fast-4g');
+    expect(result.thresholds.performance).toBe(90);
+    expect(result.buffers.performance).toBe(5);
+    expect(result.categories).toEqual(['performance', 'accessibility', 'best-practices', 'seo']);
+    expect(result.formFactor).toBe('mobile');
+    expect(result.warmup).toBe(false);
+    expect(result.name).toBe('lighthouse-my-test');
+    expect(result.skipAudits).toEqual([]);
+  });
+
+  it('should use custom throttling settings', () => {
+    const config: LighthouseTestConfig = {
+      throttling: { cpu: 6, network: 'slow-3g' },
+      thresholds: { performance: 80 },
+    };
+
+    const result = resolveConfig(config, 'test');
+
+    expect(result.throttling.cpu).toBe(6);
+    expect(result.throttling.network).toBe('slow-3g');
+  });
+
+  it('should handle custom network conditions', () => {
+    const config: LighthouseTestConfig = {
+      throttling: {
+        network: { latencyMs: 200, downloadKbps: 1000, uploadKbps: 500 },
+      },
+      thresholds: { performance: 80 },
+    };
+
+    const result = resolveConfig(config, 'test');
+
+    expect(result.throttling.network).toEqual({
+      latencyMs: 200,
+      downloadKbps: 1000,
+      uploadKbps: 500,
+    });
+  });
+
+  it('should handle all categories', () => {
+    const config: LighthouseTestConfig = {
+      thresholds: { performance: 90 },
+      categories: ['performance', 'accessibility', 'pwa'],
+    };
+
+    const result = resolveConfig(config, 'test');
+
+    expect(result.categories).toEqual(['performance', 'accessibility', 'pwa']);
+  });
+
+  it('should handle desktop form factor', () => {
+    const config: LighthouseTestConfig = {
+      thresholds: { performance: 90 },
+      formFactor: 'desktop',
+    };
+
+    const result = resolveConfig(config, 'test');
+
+    expect(result.formFactor).toBe('desktop');
+  });
+
+  it('should handle skip audits', () => {
+    const config: LighthouseTestConfig = {
+      thresholds: { performance: 90 },
+      skipAudits: ['robots-txt', 'canonical'],
+    };
+
+    const result = resolveConfig(config, 'test');
+
+    expect(result.skipAudits).toEqual(['robots-txt', 'canonical']);
+  });
+
+  it('should generate artifact name from title', () => {
+    const config: LighthouseTestConfig = {
+      thresholds: { performance: 90 },
+    };
+
+    const result = resolveConfig(config, 'My Homepage Test');
+
+    expect(result.name).toBe('lighthouse-my-homepage-test');
+  });
+
+  it('should use custom name if provided', () => {
+    const config: LighthouseTestConfig = {
+      thresholds: { performance: 90 },
+      name: 'custom-audit-name',
+    };
+
+    const result = resolveConfig(config, 'test');
+
+    expect(result.name).toBe('custom-audit-name');
+  });
+});
+
+describe('mapToLighthouseThrottling', () => {
+  it('should map network preset to Lighthouse settings', () => {
+    const result = mapToLighthouseThrottling(4, 'fast-3g');
+
+    expect(result.cpuSlowdownMultiplier).toBe(4);
+    expect(result.requestLatencyMs).toBe(150);
+    expect(result.rttMs).toBe(150);
+    // NETWORK_PRESETS['fast-3g'].downloadThroughput = (1.6 * 1024 * 1024) / 8 bytes/s = 209715.2 bytes/s
+    // Convert to Kbps: (bytes/s * 8) / 1024 = 1638.4 Kbps
+    expect(result.downloadThroughputKbps).toBe(1638.4);
+  });
+
+  it('should handle slow-3g preset', () => {
+    const result = mapToLighthouseThrottling(6, 'slow-3g');
+
+    expect(result.cpuSlowdownMultiplier).toBe(6);
+    expect(result.requestLatencyMs).toBe(400);
+    expect(result.downloadThroughputKbps).toBe(500);
+  });
+
+  it('should handle custom network conditions', () => {
+    const result = mapToLighthouseThrottling(4, {
+      latencyMs: 100,
+      downloadKbps: 2000,
+      uploadKbps: 1000,
+    });
+
+    expect(result.cpuSlowdownMultiplier).toBe(4);
+    expect(result.requestLatencyMs).toBe(100);
+    expect(result.downloadThroughputKbps).toBe(2000);
+    expect(result.uploadThroughputKbps).toBe(1000);
+    expect(result.rttMs).toBe(100);
+  });
+});
+
+describe('formatThrottling', () => {
+  it('should format preset network', () => {
+    const result = formatThrottling(4, 'fast-3g');
+    expect(result).toBe('CPU 4x, Network: fast-3g');
+  });
+
+  it('should format custom network conditions', () => {
+    const result = formatThrottling(6, {
+      latencyMs: 100,
+      downloadKbps: 2000,
+      uploadKbps: 1000,
+    });
+    expect(result).toBe('CPU 6x, Network: 2000Kbps');
+  });
+});
+
+describe('createConfiguredTestInfo', () => {
+  it('should create configured test info with resolved config', () => {
+    const mockTestInfo = {
+      title: 'test title',
+      annotations: [],
+    } as unknown as TestInfo;
+
+    const config: LighthouseTestConfig = {
+      thresholds: { performance: 90, accessibility: 95 },
+    };
+
+    const result = createConfiguredTestInfo(mockTestInfo, config, 'my test');
+
+    expect(result.title).toBe('test title');
+    expect(result.thresholds.performance).toBe(90);
+    expect(result.thresholds.accessibility).toBe(95);
+    expect(result.throttling.cpu).toBe(4);
+    expect(result.name).toBe('lighthouse-my-test');
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     index: 'src/index.ts',
     'react/index': 'src/react/index.ts',
     'playwright/index': 'src/playwright/index.ts',
+    'lighthouse/index': 'src/lighthouse/index.ts',
   },
   // Generate both ESM and CJS formats
   format: ['esm', 'cjs'],
@@ -22,5 +23,5 @@ export default defineConfig({
   // Don't split chunks (simpler for library consumers)
   splitting: false,
   // External packages (peer deps)
-  external: ['react', 'react-dom', '@playwright/test', 'playwright-core'],
+  external: ['react', 'react-dom', '@playwright/test', 'playwright-core', 'lighthouse'],
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       '@': path.resolve(__dirname, 'src'),
       '@lib/react': path.resolve(__dirname, 'src/react'),
       '@lib/playwright': path.resolve(__dirname, 'src/playwright'),
+      '@lib/lighthouse': path.resolve(__dirname, 'src/lighthouse'),
     },
   },
   test: {


### PR DESCRIPTION
Add a separate `test.lighthouse()` decorator for running Google Lighthouse
audits as part of Playwright tests. This is completely separate from the
existing `test.performance()` decorator.

Key features:
- `createLighthouseTest()` factory that extends Playwright test
- Score thresholds for all 5 Lighthouse categories
- Environment-specific thresholds (base/ci)
- Buffer tolerance (subtractive for scores)
- Network preset reuse from playwright module
- CPU and network throttling support
- Warmup audit option
- JSON artifact attachment for test reports

New files:
- src/lighthouse/ (6 files)
- tests/unit/lighthouse/ (2 test files)
- tests/integration/e2e-lighthouse.spec.ts
- site/pages/docs/guides/lighthouse.mdx

Configuration updates:
- package.json: added lighthouse peer dependency + export
- tsup.config.ts: added lighthouse entry point
- vitest.config.ts: added @lib/lighthouse alias
- eslint.config.js: added no-console exception for assertions